### PR TITLE
- Imported latest Trafilm.Metadata NuGet package that can calculate a…

### DIFF
--- a/L3occurence/metadata/default.aspx.cs
+++ b/L3occurence/metadata/default.aspx.cs
@@ -1,6 +1,6 @@
 ﻿//Project: Trafilm.Gallery (http://github.com/zoomicon/Trafilm.Gallery)
 //Filename: L3occurence\metadata\default.aspx.cs
-//Version: 20160517
+//Version: 20160522
 
 using Metadata.CXML;
 using Trafilm.Metadata;
@@ -22,7 +22,7 @@ namespace Trafilm.Gallery
     {
       filmStorage = new CXMLFragmentStorage<IFilm, Film>(Path.Combine(Request.PhysicalApplicationPath, @"film\films.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"film\metadata"), "*.cxml");
       conversationStorage = new CXMLFragmentStorage<IConversation, Conversation>(Path.Combine(Request.PhysicalApplicationPath, @"conversation\conversations.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"conversation\metadata"), listFilms.SelectedValue + ".*.cxml");
-      L3occurenceStorage = new CXMLFragmentStorage<IL3occurence, L3occurence>(Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\L3occurences.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\metadata"), listFilms.SelectedValue + ".*.cxml");
+      l3occurenceStorage = new CXMLFragmentStorage<IL3occurence, L3occurence>(Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\L3occurences.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\metadata"), listConversations.SelectedValue + ".*.cxml");
 
       UpdateFilmsList(listFilms, (IsPostBack) ? listFilms.SelectedValue : "film", !IsPostBack);
       if (!IsPostBack)
@@ -69,7 +69,7 @@ namespace Trafilm.Gallery
 
     public void DisplayMetadata(string L3occurenceId)
     {
-      DisplayMetadata(L3occurenceStorage[L3occurenceId]);
+      DisplayMetadata(l3occurenceStorage[L3occurenceId]);
     }
 
     public void DisplayMetadata(IL3occurence metadata)
@@ -195,12 +195,12 @@ namespace Trafilm.Gallery
     public void Save()
     {
       lblInfoUpdated.Text = DateTime.UtcNow.ToString(CXML.DEFAULT_DATETIME_FORMAT);
-      L3occurenceStorage[listL3occurences.SelectedValue] = (IL3occurence)GetMetadataFromUI();
+      l3occurenceStorage[listL3occurences.SelectedValue] = (IL3occurence)GetMetadataFromUI();
     }
 
     public void SaveCollection()
     {
-      SaveCollection(Path.Combine(Request.PhysicalApplicationPath, "L3occurence/L3occurences.cxml"), "Trafilm Gallery L3occurences", L3occurence.MakeL3occurenceFacetCategories(), L3occurenceStorage.Values);
+      SaveCollection(Path.Combine(Request.PhysicalApplicationPath, "L3occurence/L3occurences.cxml"), "Trafilm Gallery L3occurences", L3occurence.MakeL3occurenceFacetCategories(), l3occurenceStorage.Values);
     }
 
     #endregion
@@ -220,7 +220,7 @@ namespace Trafilm.Gallery
 
     protected void listConversations_SelectedIndexChanged(object sender, EventArgs e)
     {
-      L3occurenceStorage = new CXMLFragmentStorage<IL3occurence, L3occurence>(Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\L3occurences.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\metadata"), listConversations.SelectedValue + ".*.cxml");
+      l3occurenceStorage = new CXMLFragmentStorage<IL3occurence, L3occurence>(Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\L3occurences.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\metadata"), listConversations.SelectedValue + ".*.cxml");
 
       bool visible = (listConversations.SelectedIndex > 0);
       panelL3occurenceId.Visible = visible;

--- a/Trafilm.Gallery.csproj
+++ b/Trafilm.Gallery.csproj
@@ -157,7 +157,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Trafilm.Metadata, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Trafilm.Metadata.4.3.0\lib\portable-net403+sl5+win8+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Trafilm.Metadata.dll</HintPath>
+      <HintPath>packages\Trafilm.Metadata.4.4.0\lib\portable-net403+sl5+win8+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Trafilm.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/conversation/metadata/default.aspx.cs
+++ b/conversation/metadata/default.aspx.cs
@@ -1,6 +1,6 @@
 ﻿//Project: Trafilm.Gallery (http://github.com/zoomicon/Trafilm.Gallery)
 //Filename: conversation\metadata\default.aspx.cs
-//Version: 20160517
+//Version: 20160522
 
 using Metadata.CXML;
 using Trafilm.Metadata;
@@ -23,7 +23,7 @@ namespace Trafilm.Gallery
     {
       filmStorage = new CXMLFragmentStorage<IFilm, Film>(Path.Combine(Request.PhysicalApplicationPath, @"film\films.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"film\metadata"), "*.cxml");
       conversationStorage = new CXMLFragmentStorage<IConversation, Conversation>(Path.Combine(Request.PhysicalApplicationPath, @"conversation\conversations.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"conversation\metadata"), listFilms.SelectedValue + ".*.cxml");
-      L3occurenceStorage = new CXMLFragmentStorage<IL3occurence, L3occurence>(Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\L3occurences.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\metadata"), listFilms.SelectedValue + ".*.cxml");
+      l3occurenceStorage = new CXMLFragmentStorage<IL3occurence, L3occurence>(Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\L3occurences.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\metadata"), listConversations.SelectedValue + ".*.cxml");
 
       if (!IsPostBack)
       {
@@ -59,7 +59,10 @@ namespace Trafilm.Gallery
 
     public void DisplayMetadata(string conversationId)
     {
-      DisplayMetadata(conversationStorage[conversationId]);
+      IConversation metadata = conversationStorage[conversationId];
+      l3occurenceStorage = new CXMLFragmentStorage<IL3occurence, L3occurence>(Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\L3occurences.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\metadata"), conversationId + ".*.cxml");
+      metadata.L3occurences = l3occurenceStorage.Values; //this updates calculated properties //assumes "l3occurenceStorage" has been updated
+      DisplayMetadata(metadata);
     }
 
     public void DisplayMetadata(IConversation metadata)
@@ -94,15 +97,15 @@ namespace Trafilm.Gallery
       UI.Load(listSpeakingCharactersCount, metadata.SpeakingCharactersCount);
       UI.Load(listL3speakingCharactersCount, metadata.L3speakingCharactersCount);
 
-      //Calculatable from L3occurences//
+      //Calculated properties//
 
-      UI.Load(lblL3languagesCount, CalculateL3languagesCount(key).ToString());
-      clistL3languages.DataSource = CalculateL3languages(key);
+      UI.Load(lblL3languagesCount, metadata.L3languagesCount.ToString());
+      clistL3languages.DataSource = metadata.L3languages;
 
-      UI.Load(lblL3languageTypesCount, CalculateL3languageTypesCount(key).ToString());
-      clistL3languageTypes.DataSource = CalculateL3languageTypes(key);
+      UI.Load(lblL3languageTypesCount, metadata.L3languageTypesCount.ToString());
+      clistL3languageTypes.DataSource = metadata.L3languageTypes;
 
-      UI.Load(lblL3occurenceCount, CalculateL3occurenceCount(key).ToString());
+      UI.Load(lblL3occurenceCount, metadata.L3occurenceCount.ToString());
     }
 
     #endregion
@@ -141,15 +144,10 @@ namespace Trafilm.Gallery
       metadata.SpeakingCharactersCount = listSpeakingCharactersCount.SelectedValue; //e.g. 1, 2, 3, more than 3
       metadata.L3speakingCharactersCount = listL3speakingCharactersCount.SelectedValue; //e.g. 1, 2, 3, more than 3
 
-      //Calculatable from L3occurences//
+      //Calculated properties//
 
-      metadata.L3languagesCount = CalculateL3languagesCount(key);
-      metadata.L3languages = CalculateL3languages(key);
-
-      metadata.L3languageTypesCount = CalculateL3languageTypesCount(key);
-      metadata.L3languageTypes = CalculateL3languageTypes(key);
-
-      metadata.L3occurenceCount = CalculateL3occurenceCount(key);
+      l3occurenceStorage = new CXMLFragmentStorage<IL3occurence, L3occurence>(Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\L3occurences.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\metadata"), key + ".*.cxml");
+      metadata.L3occurences = l3occurenceStorage.Values; //this updates calculated properties //assumes "l3occurenceStorage" has been updated
 
       return metadata;
     }
@@ -191,7 +189,7 @@ namespace Trafilm.Gallery
 
     private int CalculateL3occurenceCount(string key)
     {
-      return L3occurenceStorage.Count;
+      return l3occurenceStorage.Count;
     }
 
     #endregion
@@ -211,7 +209,7 @@ namespace Trafilm.Gallery
 
     protected void listConversations_SelectedIndexChanged(object sender, EventArgs e)
     {
-      L3occurenceStorage = new CXMLFragmentStorage<IL3occurence, L3occurence>(Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\L3occurences.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\metadata"), listFilms.SelectedValue + ".*.cxml");
+      l3occurenceStorage = new CXMLFragmentStorage<IL3occurence, L3occurence>(Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\L3occurences.cxml"), Path.Combine(Request.PhysicalApplicationPath, @"L3occurence\metadata"), listConversations.SelectedValue + ".*.cxml");
 
       bool visible = (listConversations.SelectedIndex > 0);
       panelMetadata.Visible = visible;
@@ -219,7 +217,7 @@ namespace Trafilm.Gallery
       if (visible)
       {
         DisplayMetadata(listConversations.SelectedValue);
-        UpdateRepeater(repeaterL3occurences, L3occurenceStorage.Keys.Select(x=> new { filmId=listFilms.SelectedValue, conversationId=listConversations.SelectedValue, L3occurenceId = x }) );
+        UpdateRepeater(repeaterL3occurences, l3occurenceStorage.Keys.Select(x=> new { filmId=listFilms.SelectedValue, conversationId=listConversations.SelectedValue, L3occurenceId = x }) );
       }
     }
 

--- a/metadata/BaseMetadataPage.cs
+++ b/metadata/BaseMetadataPage.cs
@@ -23,7 +23,7 @@ namespace Trafilm.Gallery
 
     protected CXMLFragmentStorage<IFilm, Film> filmStorage;
     protected CXMLFragmentStorage<IConversation, Conversation> conversationStorage;
-    protected CXMLFragmentStorage<IL3occurence, L3occurence> L3occurenceStorage;
+    protected CXMLFragmentStorage<IL3occurence, L3occurence> l3occurenceStorage;
 
     #endregion
 
@@ -72,7 +72,7 @@ namespace Trafilm.Gallery
 
     public void CreateL3occurence(string filmId, string conversationId, string L3occurenceId, IL3occurence metadata = null) //don't return IL3occurence to avoid loading a .CXML file if already exists
     {
-      if (!L3occurenceStorage.Keys.Contains(L3occurenceId))
+      if (!l3occurenceStorage.Keys.Contains(L3occurenceId))
       {
         if (metadata == null)
         {
@@ -87,7 +87,7 @@ namespace Trafilm.Gallery
         metadata.Title = L3occurenceId;
         metadata.ReferenceId = L3occurenceId;
 
-        L3occurenceStorage[L3occurenceId] = metadata;
+        l3occurenceStorage[L3occurenceId] = metadata;
       }
     }
 
@@ -132,7 +132,7 @@ namespace Trafilm.Gallery
 
     public void UpdateL3occurencesList(ListControl list, string selectedValue = null, bool isQueryStringItem = false)
     {
-      UpdateList(list, L3occurenceStorage.Keys, selectedValue, isQueryStringItem);
+      UpdateList(list, l3occurenceStorage.Keys, selectedValue, isQueryStringItem);
     }
 
     #endregion

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Metadata.CXML" version="1.1.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Trafilm.Metadata" version="4.3.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Trafilm.Metadata" version="4.4.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
…ggregate properties from child objects of Film and Conversation objects (which are Conversations and L3occurences respectively)
- Fixed L3occurenceStorage initialization code at Conversation (used to show list of child L3occurences and to calculate aggregate properties from L3occurences), removed from Film (unused)
